### PR TITLE
Add cmake support to build with AVX2 & C++14/17

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -3,10 +3,12 @@ project(xndarr)
 add_executable(xndarr main.cpp)
 
 
-set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
+set(CMAKE_CXX_FLAGS "-O3 -Wall -Werror")
 
-target_compile_features(xndarr PUBLIC cxx_std_14)
+target_compile_options(xndarr PUBLIC "--std=c++17")
+target_compile_options(xndarr PUBLIC "-mavx2")
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -40,7 +40,9 @@ int main() {
   _mm256_storeu_ps(&z.data()[0], data);
 
   cout << "SIMD eval of 8 floats: ";
-  for(szt i=0; i<z.size(); ++i) cout << z.data()[i] << " "; cout << endl;
+  for(szt i=0; i<z.size(); ++i)
+    cout << z.data()[i] << " ";
+  cout << endl;
 
   return 0;
 }


### PR DESCRIPTION
- Addresses #1
- Added AVX2 and C++17 compilation support.
- Added CMAKE_CXX_FLAGS i.e C++ flags support.